### PR TITLE
refactor: update import statements to use "qml_rs" package name

### DIFF
--- a/examples/basic_job.rs
+++ b/examples/basic_job.rs
@@ -12,7 +12,7 @@
 //! ```
 
 use chrono::{Duration, Utc};
-use qml::{Job, JobState, QmlError};
+use qml_rs::{Job, JobState, QmlError};
 
 fn main() -> Result<(), QmlError> {
     println!("🚀 QML Rust - Basic Job Example");

--- a/examples/dashboard_demo.rs
+++ b/examples/dashboard_demo.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 use tracing::{error, info};
 
-use qml::{
+use qml_rs::{
     DashboardConfig,
     // Dashboard
     DashboardServer,

--- a/examples/processing_demo.rs
+++ b/examples/processing_demo.rs
@@ -14,7 +14,7 @@
 
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
-use qml::{
+use qml_rs::{
     BackgroundJobServer, Job, JobScheduler, RetryPolicy, RetryStrategy, ServerConfig, Storage,
     StorageInstance, Worker, WorkerContext, WorkerRegistry, WorkerResult,
 };
@@ -45,7 +45,7 @@ impl EmailWorker {
 
 #[async_trait]
 impl Worker for EmailWorker {
-    async fn execute(&self, job: &Job, context: &WorkerContext) -> qml::Result<WorkerResult> {
+    async fn execute(&self, job: &Job, context: &WorkerContext) -> qml_rs::Result<WorkerResult> {
         let email = &job.arguments[0];
         let _message = &job.arguments[1];
 
@@ -96,7 +96,7 @@ impl PaymentWorker {
 
 #[async_trait]
 impl Worker for PaymentWorker {
-    async fn execute(&self, job: &Job, _context: &WorkerContext) -> qml::Result<WorkerResult> {
+    async fn execute(&self, job: &Job, _context: &WorkerContext) -> qml_rs::Result<WorkerResult> {
         let order_id = &job.arguments[0];
         let amount = &job.arguments[1];
 
@@ -132,7 +132,7 @@ struct ReportWorker;
 
 #[async_trait]
 impl Worker for ReportWorker {
-    async fn execute(&self, job: &Job, _context: &WorkerContext) -> qml::Result<WorkerResult> {
+    async fn execute(&self, job: &Job, _context: &WorkerContext) -> qml_rs::Result<WorkerResult> {
         let report_type = &job.arguments[0];
         let period = &job.arguments[1];
 
@@ -279,11 +279,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n📊 Job Processing Results:");
     for (state, count) in &job_counts {
         let state_name = match state {
-            qml::JobState::Succeeded { .. } => "✅ Succeeded",
-            qml::JobState::Failed { .. } => "❌ Failed",
-            qml::JobState::Processing { .. } => "🔄 Processing",
-            qml::JobState::AwaitingRetry { .. } => "⏳ Awaiting Retry",
-            qml::JobState::Enqueued { .. } => "📥 Enqueued",
+            qml_rs::JobState::Succeeded { .. } => "✅ Succeeded",
+            qml_rs::JobState::Failed { .. } => "❌ Failed",
+            qml_rs::JobState::Processing { .. } => "🔄 Processing",
+            qml_rs::JobState::AwaitingRetry { .. } => "⏳ Awaiting Retry",
+            qml_rs::JobState::Enqueued { .. } => "📥 Enqueued",
             _ => "📝 Other",
         };
         println!("   {} {}", state_name, count);
@@ -358,12 +358,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n📊 Final Job Counts:");
     for (state, count) in &final_counts {
         let state_name = match state {
-            qml::JobState::Succeeded { .. } => "✅ Succeeded",
-            qml::JobState::Failed { .. } => "❌ Failed",
-            qml::JobState::Scheduled { .. } => "📅 Scheduled",
-            qml::JobState::Processing { .. } => "🔄 Processing",
-            qml::JobState::AwaitingRetry { .. } => "⏳ Awaiting Retry",
-            qml::JobState::Enqueued { .. } => "📥 Enqueued",
+            qml_rs::JobState::Succeeded { .. } => "✅ Succeeded",
+            qml_rs::JobState::Failed { .. } => "❌ Failed",
+            qml_rs::JobState::Scheduled { .. } => "📅 Scheduled",
+            qml_rs::JobState::Processing { .. } => "🔄 Processing",
+            qml_rs::JobState::AwaitingRetry { .. } => "⏳ Awaiting Retry",
+            qml_rs::JobState::Enqueued { .. } => "📥 Enqueued",
             _ => "📝 Other",
         };
         println!("   {} {}", state_name, count);
@@ -393,10 +393,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("📋 Job execution analysis:");
     for job in all_jobs {
         let status = match &job.state {
-            qml::JobState::Succeeded { total_duration, .. } => {
+            qml_rs::JobState::Succeeded { total_duration, .. } => {
                 format!("✅ Succeeded in {}ms", total_duration)
             }
-            qml::JobState::Failed {
+            qml_rs::JobState::Failed {
                 exception,
                 retry_count,
                 ..
@@ -407,7 +407,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     exception
                 )
             }
-            qml::JobState::AwaitingRetry {
+            qml_rs::JobState::AwaitingRetry {
                 retry_count,
                 last_exception,
                 ..

--- a/examples/storage_demo.rs
+++ b/examples/storage_demo.rs
@@ -1,10 +1,10 @@
-use qml::{
+use qml_rs::{
     Job, JobState, Storage,
     storage::{MemoryConfig, StorageConfig, StorageInstance},
 };
 
 #[cfg(feature = "redis")]
-use qml::storage::RedisConfig;
+use qml_rs::storage::RedisConfig;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/core/job.rs
+++ b/src/core/job.rs
@@ -17,7 +17,7 @@
 //!
 //! ### Basic Job Creation
 //! ```rust
-//! use qml::Job;
+//! use qml_rs::Job;
 //!
 //! // Simple job with method and arguments
 //! let job = Job::new("send_email", vec!["user@example.com".to_string()]);
@@ -34,7 +34,7 @@
 //!
 //! ### Job Serialization
 //! ```rust
-//! use qml::Job;
+//! use qml_rs::Job;
 //!
 //! let job = Job::new("process_data", vec!["file.csv".to_string()]);
 //!
@@ -49,7 +49,7 @@
 //!
 //! ### State Management
 //! ```rust
-//! use qml::{Job, JobState};
+//! use qml_rs::{Job, JobState};
 //!
 //! let mut job = Job::new("generate_report", vec!["Q4".to_string()]);
 //!
@@ -62,7 +62,7 @@
 //!
 //! ### Metadata and Configuration
 //! ```rust
-//! use qml::Job;
+//! use qml_rs::Job;
 //!
 //! let mut job = Job::new("backup_database", vec!["production".to_string()]);
 //!
@@ -110,7 +110,7 @@ use uuid::Uuid;
 ///
 /// ### Creating Jobs
 /// ```rust
-/// use qml::Job;
+/// use qml_rs::Job;
 ///
 /// // Basic job
 /// let job = Job::new("process_order", vec!["order_123".to_string()]);
@@ -127,7 +127,7 @@ use uuid::Uuid;
 ///
 /// ### Working with Job Data
 /// ```rust
-/// use qml::Job;
+/// use qml_rs::Job;
 ///
 /// let mut job = Job::new("analyze_data", vec!["dataset.csv".to_string()]);
 ///
@@ -166,7 +166,7 @@ pub struct Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// let job = Job::new("process_user", vec![
     ///     "123".to_string(),                    // user_id
@@ -198,7 +198,7 @@ pub struct Job {
     ///
     /// ## Example Queue Organization
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// let critical_job = Job::with_config("send_alert", vec![], "critical", 10, 1);
     /// let normal_job = Job::with_config("send_email", vec![], "normal", 5, 3);
@@ -233,7 +233,7 @@ pub struct Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// let mut job = Job::new("process_order", vec!["order_123".to_string()]);
     /// job.add_metadata("customer_id", "456");
@@ -255,7 +255,7 @@ pub struct Job {
     ///
     /// ## Example Timeouts
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// let mut quick_job = Job::new("send_sms", vec![]);
     /// quick_job.set_timeout(30); // 30 seconds
@@ -284,7 +284,7 @@ impl Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// // Simple job
     /// let job = Job::new("send_email", vec!["user@example.com".to_string()]);
@@ -333,7 +333,7 @@ impl Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// // High-priority payment job with retries
     /// let job = Job::with_config(
@@ -385,7 +385,7 @@ impl Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// let job = Job::new("process_data", vec!["file.csv".to_string()]);
     /// let json = job.serialize().unwrap();
@@ -413,7 +413,7 @@ impl Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// // Serialize a job
     /// let original = Job::new("test_method", vec!["arg1".to_string()]);
@@ -453,7 +453,7 @@ impl Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::{Job, JobState};
+    /// use qml_rs::{Job, JobState};
     ///
     /// let mut job = Job::new("test_job", vec![]);
     ///
@@ -490,7 +490,7 @@ impl Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// let mut job = Job::new("process_user", vec!["123".to_string()]);
     ///
@@ -515,7 +515,7 @@ impl Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// let mut email_job = Job::new("send_welcome_email", vec![]);
     /// email_job.set_type("notification");
@@ -540,7 +540,7 @@ impl Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// let mut quick_job = Job::new("send_sms", vec![]);
     /// quick_job.set_timeout(30); // 30 seconds max
@@ -565,7 +565,7 @@ impl Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     /// use std::thread;
     /// use std::time::Duration;
     ///
@@ -594,7 +594,7 @@ impl Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// let mut job = Job::new("long_running_task", vec![]);
     /// job.set_timeout(5); // 5 second timeout
@@ -624,7 +624,7 @@ impl Job {
     ///
     /// ## Example
     /// ```rust
-    /// use qml::Job;
+    /// use qml_rs::Job;
     ///
     /// let original = Job::new("process_data", vec!["file.csv".to_string()]);
     /// let copy = original.clone_with_new_id();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! # qml
+//! # qml-rs
 //!
 //! A production-ready Rust implementation of background job processing.
 //!
@@ -19,7 +19,7 @@
 //!
 //! ### Memory Storage (Development/Testing)
 //! ```rust
-//! use qml::{MemoryStorage, Job, Storage};
+//! use qml_rs::{MemoryStorage, Job, Storage};
 //! use std::sync::Arc;
 //!
 //! # tokio_test::block_on(async {
@@ -33,7 +33,7 @@
 //! ```rust,ignore
 //! #[cfg(feature = "redis")]
 //! async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//!     use qml::storage::{RedisConfig, StorageInstance};
+//!     use qml_rs::storage::{RedisConfig, StorageInstance};
 //!     use std::time::Duration;
 //!     let config = RedisConfig::new()
 //!         .with_url("redis://localhost:6379")
@@ -49,7 +49,7 @@
 //! ```rust,ignore
 //! #[cfg(feature = "postgres")]
 //! async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//!     use qml::storage::{PostgresConfig, StorageInstance};
+//!     use qml_rs::storage::{PostgresConfig, StorageInstance};
 //!     use std::sync::Arc;
 //!     let config = PostgresConfig::new()
 //!         .with_database_url("postgresql://user:pass@localhost:5432/qml")
@@ -65,7 +65,7 @@
 //!
 //! ### Basic Worker Implementation
 //! ```rust
-//! use qml::{Worker, Job, WorkerContext, WorkerResult, QmlError};
+//! use qml_rs::{Worker, Job, WorkerContext, WorkerResult, QmlError};
 //! use async_trait::async_trait;
 //!
 //! struct EmailWorker;
@@ -87,7 +87,7 @@
 //!
 //! ### Complete Job Server Setup
 //! ```rust
-//! use qml::{
+//! use qml_rs::{
 //!     BackgroundJobServer, MemoryStorage, ServerConfig,
 //!     WorkerRegistry, Job
 //! };
@@ -115,7 +115,7 @@
 //!
 //! ### Real-time Web Dashboard
 //! ```rust
-//! use qml::{DashboardServer, MemoryStorage};
+//! use qml_rs::{DashboardServer, MemoryStorage};
 //! use std::sync::Arc;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -143,7 +143,7 @@
 //! - **Memory**: Mutex-based locking with automatic cleanup
 //!
 //! ```rust
-//! use qml::{Storage, MemoryStorage};
+//! use qml_rs::{Storage, MemoryStorage};
 //!
 //! # tokio_test::block_on(async {
 //! let storage = MemoryStorage::new();
@@ -171,7 +171,7 @@
 //!
 //! ### State Management Example
 //! ```rust
-//! use qml::{Job, JobState};
+//! use qml_rs::{Job, JobState};
 //!
 //! let mut job = Job::new("process_payment", vec!["order_123".to_string()]);
 //!
@@ -191,9 +191,9 @@
 //! ```rust,ignore
 //! #[cfg(feature = "postgres")]
 //! async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//!     use qml::storage::{PostgresConfig, StorageInstance};
+//!     use qml_rs::storage::{PostgresConfig, StorageInstance};
 //!     use std::sync::Arc;
-//!     use qml::{BackgroundJobServer, DashboardServer, ServerConfig, WorkerRegistry};
+//!     use qml_rs::{BackgroundJobServer, DashboardServer, ServerConfig, WorkerRegistry};
 //!     let storage_config = PostgresConfig::new()
 //!         .with_database_url(std::env::var("DATABASE_URL")?)
 //!         .with_auto_migrate(true)
@@ -223,7 +223,7 @@
 //!
 //! ### Server Configuration
 //! ```rust
-//! use qml::ServerConfig;
+//! use qml_rs::ServerConfig;
 //! use chrono::Duration;
 //!
 //! let config = ServerConfig::new("production-server")
@@ -238,7 +238,7 @@
 //! ### PostgreSQL Configuration
 //! ```rust,ignore
 //! #[cfg(feature = "postgres")]
-//! use qml::storage::PostgresConfig;
+//! use qml_rs::storage::PostgresConfig;
 //! use std::time::Duration;
 //!
 //! let config = PostgresConfig::new()
@@ -253,7 +253,7 @@
 //!
 //! ### Unit Testing with Memory Storage
 //! ```rust
-//! use qml::{MemoryStorage, Job, Storage};
+//! use qml_rs::{MemoryStorage, Job, Storage};
 //!
 //! #[tokio::test]
 //! async fn test_job_processing() {
@@ -269,7 +269,7 @@
 //!
 //! ### Stress Testing
 //! ```rust
-//! use qml::{MemoryStorage, Job, Storage};
+//! use qml_rs::{MemoryStorage, Job, Storage};
 //! use futures::future::join_all;
 //!
 //! #[tokio::test]
@@ -297,7 +297,7 @@
 //! Comprehensive error types for robust error handling:
 //!
 //! ```rust
-//! use qml::{QmlError, Result};
+//! use qml_rs::{QmlError, Result};
 //!
 //! fn handle_job_error(result: Result<()>) {
 //!     match result {
@@ -354,7 +354,7 @@
 //!
 //! See the [examples] for complete working implementations.
 //!
-//! [examples]: 
+//! [examples]:
 
 pub mod core;
 pub mod dashboard;

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -270,6 +270,7 @@ impl Default for PostgresConfig {
         Self {
             database_url: std::env::var("DATABASE_URL")
                 .expect("DATABASE_URL environment variable must be set"),
+            migrations_path: "./migrations".to_string(),
             max_connections: 20,
             min_connections: 1,
             connect_timeout: Duration::from_secs(30),
@@ -293,6 +294,12 @@ impl PostgresConfig {
     /// Set the database URL
     pub fn with_database_url<S: Into<String>>(mut self, url: S) -> Self {
         self.database_url = url.into();
+        self
+    }
+
+    /// Set the migrations path
+    pub fn with_migrations_path<S: Into<String>>(mut self, path: S) -> Self {
+        self.migrations_path = path.into();
         self
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -64,7 +64,7 @@ pub use redis::RedisStorage;
 ///
 /// ### Basic Storage Operations
 /// ```rust
-/// use qml::{MemoryStorage, Job, Storage};
+/// use qml_rs::{MemoryStorage, Job, Storage};
 ///
 /// # tokio_test::block_on(async {
 /// let storage = MemoryStorage::new();
@@ -79,7 +79,7 @@ pub use redis::RedisStorage;
 ///
 /// // Update job state
 /// let mut updated_job = retrieved;
-/// updated_job.set_state(qml::JobState::processing("worker-1", "server-1")).unwrap();
+/// updated_job.set_state(qml_rs::JobState::processing("worker-1", "server-1")).unwrap();
 /// storage.update(&updated_job).await.unwrap();
 ///
 /// // Delete the job
@@ -90,7 +90,7 @@ pub use redis::RedisStorage;
 ///
 /// ### Atomic Job Processing
 /// ```rust
-/// use qml::{MemoryStorage, Job, Storage};
+/// use qml_rs::{MemoryStorage, Job, Storage};
 ///
 /// # tokio_test::block_on(async {
 /// let storage = MemoryStorage::new();
@@ -115,7 +115,7 @@ pub use redis::RedisStorage;
 ///
 /// ### Storage Backend Selection
 /// ```rust
-/// use qml::storage::{StorageInstance, StorageConfig, MemoryConfig};
+/// use qml_rs::storage::{StorageInstance, StorageConfig, MemoryConfig};
 ///
 /// # tokio_test::block_on(async {
 /// // Memory storage for development
@@ -124,7 +124,7 @@ pub use redis::RedisStorage;
 /// // Redis storage for production
 /// # #[cfg(feature = "redis")]
 /// # {
-/// use qml::storage::RedisConfig;
+/// use qml_rs::storage::RedisConfig;
 /// let redis_config = RedisConfig::new().with_url("redis://localhost:6379");
 /// match StorageInstance::redis(redis_config).await {
 ///     Ok(redis_storage) => println!("Redis storage ready"),
@@ -135,7 +135,7 @@ pub use redis::RedisStorage;
 /// // PostgreSQL storage for enterprise
 /// # #[cfg(feature = "postgres")]
 /// # {
-/// use qml::storage::PostgresConfig;
+/// use qml_rs::storage::PostgresConfig;
 /// let pg_config = PostgresConfig::new()
 ///     .with_database_url("postgresql://localhost:5432/qml")
 ///     .with_auto_migrate(true);
@@ -149,7 +149,7 @@ pub use redis::RedisStorage;
 ///
 /// ### Job Filtering and Statistics
 /// ```rust
-/// use qml::{MemoryStorage, Job, JobState, Storage};
+/// use qml_rs::{MemoryStorage, Job, JobState, Storage};
 ///
 /// # tokio_test::block_on(async {
 /// let storage = MemoryStorage::new();
@@ -198,7 +198,7 @@ pub trait Storage: Send + Sync {
     ///
     /// ## Examples
     /// ```rust
-    /// use qml::{MemoryStorage, Job, Storage};
+    /// use qml_rs::{MemoryStorage, Job, Storage};
     ///
     /// # tokio_test::block_on(async {
     /// let storage = MemoryStorage::new();
@@ -232,7 +232,7 @@ pub trait Storage: Send + Sync {
     ///
     /// ## Examples
     /// ```rust
-    /// use qml::{MemoryStorage, Job, Storage};
+    /// use qml_rs::{MemoryStorage, Job, Storage};
     ///
     /// # tokio_test::block_on(async {
     /// let storage = MemoryStorage::new();
@@ -265,7 +265,7 @@ pub trait Storage: Send + Sync {
     ///
     /// ## Examples
     /// ```rust
-    /// use qml::{MemoryStorage, Job, JobState, Storage};
+    /// use qml_rs::{MemoryStorage, Job, JobState, Storage};
     ///
     /// # tokio_test::block_on(async {
     /// let storage = MemoryStorage::new();
@@ -299,7 +299,7 @@ pub trait Storage: Send + Sync {
     ///
     /// ## Examples
     /// ```rust
-    /// use qml::{MemoryStorage, Job, Storage};
+    /// use qml_rs::{MemoryStorage, Job, Storage};
     ///
     /// # tokio_test::block_on(async {
     /// let storage = MemoryStorage::new();
@@ -334,7 +334,7 @@ pub trait Storage: Send + Sync {
     ///
     /// ## Examples
     /// ```rust
-    /// use qml::{MemoryStorage, Job, JobState, Storage};
+    /// use qml_rs::{MemoryStorage, Job, JobState, Storage};
     ///
     /// # tokio_test::block_on(async {
     /// let storage = MemoryStorage::new();
@@ -376,7 +376,7 @@ pub trait Storage: Send + Sync {
     ///
     /// ## Examples
     /// ```rust,ignore
-    /// use qml::{MemoryStorage, Job, JobState, Storage};
+    /// use qml_rs::{MemoryStorage, Job, JobState, Storage};
     ///
     /// # tokio_test::block_on(async {
     /// let storage = MemoryStorage::new();
@@ -415,7 +415,7 @@ pub trait Storage: Send + Sync {
     ///
     /// ## Examples
     /// ```rust
-    /// use qml::{MemoryStorage, Job, Storage};
+    /// use qml_rs::{MemoryStorage, Job, Storage};
     ///
     /// # tokio_test::block_on(async {
     /// let storage = MemoryStorage::new();
@@ -461,7 +461,7 @@ pub trait Storage: Send + Sync {
     ///
     /// ## Examples
     /// ```rust
-    /// use qml::{MemoryStorage, Job, Storage};
+    /// use qml_rs::{MemoryStorage, Job, Storage};
     ///
     /// # tokio_test::block_on(async {
     /// let storage = MemoryStorage::new();
@@ -519,7 +519,7 @@ pub trait Storage: Send + Sync {
     ///
     /// ## Examples
     /// ```rust
-    /// use qml::{MemoryStorage, Job, Storage};
+    /// use qml_rs::{MemoryStorage, Job, Storage};
     ///
     /// # tokio_test::block_on(async {
     /// let storage = MemoryStorage::new();
@@ -565,7 +565,7 @@ pub trait Storage: Send + Sync {
     ///
     /// ## Examples
     /// ```rust
-    /// use qml::{MemoryStorage, Job, Storage};
+    /// use qml_rs::{MemoryStorage, Job, Storage};
     ///
     /// # tokio_test::block_on(async {
     /// let storage = MemoryStorage::new();
@@ -605,7 +605,7 @@ pub trait Storage: Send + Sync {
     ///
     /// ## Examples
     /// ```rust
-    /// use qml::{MemoryStorage, Job, Storage};
+    /// use qml_rs::{MemoryStorage, Job, Storage};
     ///
     /// # tokio_test::block_on(async {
     /// let storage = MemoryStorage::new();
@@ -659,7 +659,7 @@ impl StorageInstance {
     /// # Examples
     ///
     /// ```rust
-    /// use qml::storage::{StorageInstance, StorageConfig, MemoryConfig};
+    /// use qml_rs::storage::{StorageInstance, StorageConfig, MemoryConfig};
     ///
     /// # tokio_test::block_on(async {
     /// let config = StorageConfig::Memory(MemoryConfig::default());
@@ -689,7 +689,7 @@ impl StorageInstance {
     /// # Examples
     ///
     /// ```rust
-    /// use qml::storage::StorageInstance;
+    /// use qml_rs::storage::StorageInstance;
     ///
     /// let storage = StorageInstance::memory();
     /// ```
@@ -705,7 +705,7 @@ impl StorageInstance {
     /// # Examples
     ///
     /// ```rust
-    /// use qml::storage::{StorageInstance, MemoryConfig};
+    /// use qml_rs::storage::{StorageInstance, MemoryConfig};
     ///
     /// let config = MemoryConfig::new().with_max_jobs(1000);
     /// let storage = StorageInstance::memory_with_config(config);
@@ -726,7 +726,7 @@ impl StorageInstance {
     /// # Examples
     ///
     /// ```rust
-    /// use qml::storage::{StorageInstance, RedisConfig};
+    /// use qml_rs::storage::{StorageInstance, RedisConfig};
     ///
     /// # tokio_test::block_on(async {
     /// let config = RedisConfig::new().with_url("redis://localhost:6379");
@@ -754,7 +754,7 @@ impl StorageInstance {
     /// # Examples
     ///
     /// ```rust
-    /// use qml::storage::{StorageInstance, PostgresConfig};
+    /// use qml_rs::storage::{StorageInstance, PostgresConfig};
     ///
     /// # tokio_test::block_on(async {
     /// let config = PostgresConfig::new().with_database_url("postgresql://postgres:password@localhost:5432/qml");

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -49,8 +49,10 @@ impl PostgresStorage {
 
     /// Run database migrations
     pub async fn migrate(&self) -> Result<(), StorageError> {
+        let migration_path = self.config.migrations_path;
+
         // Run migrations using sqlx migrate
-        sqlx::migrate!("./migrations")
+        sqlx::migrate!(migration_path)
             .run(&self.pool)
             .await
             .map_err(|e| StorageError::MigrationError {

--- a/tests/storage_integration_tests.rs
+++ b/tests/storage_integration_tests.rs
@@ -1,11 +1,11 @@
 use chrono::{Duration, Utc};
-use qml::{
+use qml_rs::{
     Job, JobState, Storage,
     storage::{MemoryConfig, StorageConfig, StorageInstance},
 };
 
 #[cfg(feature = "redis")]
-use qml::storage::RedisConfig;
+use qml_rs::storage::RedisConfig;
 
 /// Test the storage factory pattern with different configurations
 #[tokio::test]
@@ -296,4 +296,4 @@ async fn test_storage_pagination() {
 }
 
 // Re-export MemoryStorage for the concurrent test
-use qml::MemoryStorage;
+use qml_rs::MemoryStorage;

--- a/tests/unit/job_state_tests.rs
+++ b/tests/unit/job_state_tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for JobState functionality.
 
 use chrono::{Duration, Utc};
-use qml::JobState;
+use qml_rs::JobState;
 
 #[test]
 fn test_job_state_names() {

--- a/tests/unit/job_tests.rs
+++ b/tests/unit/job_tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for Job functionality.
 
 use chrono::Utc;
-use qml::{Job, JobState, QmlError};
+use qml_rs::{Job, JobState, QmlError};
 
 #[test]
 fn test_job_creation() {


### PR DESCRIPTION
- Update import statements to use `qml_rs` package name across examples and tests
- Add migrations path configuration to `PostgresConfig` and update migration method to use it