### PR TITLE
Allow direct transition to Failed state for Enqueued jobs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qml-rs"
-version = "0.1.7-alpha"
+version = "0.1.8-alpha"
 edition = "2024"
 authors = ["QML Contributors"]
 description = "A Rust implementation of QML background job processing"

--- a/src/core/job_state.rs
+++ b/src/core/job_state.rs
@@ -124,6 +124,7 @@ impl JobState {
             (Enqueued { .. }, Processing { .. }) => true,
             (Enqueued { .. }, Deleted { .. }) => true,
             (Enqueued { .. }, Scheduled { .. }) => true,
+            (Enqueued { .. }, Failed { .. }) => true, // Allow direct failure for configuration errors
 
             // From Processing
             (Processing { .. }, Succeeded { .. }) => true,

--- a/tests/unit/job_state_tests.rs
+++ b/tests/unit/job_state_tests.rs
@@ -57,7 +57,7 @@ fn test_valid_state_transitions() {
     assert!(enqueued.can_transition_to(&deleted));
     assert!(enqueued.can_transition_to(&scheduled));
     assert!(!enqueued.can_transition_to(&succeeded));
-    assert!(!enqueued.can_transition_to(&failed));
+    assert!(enqueued.can_transition_to(&failed)); // Now allowed for jobs without workers
 
     // From Processing
     assert!(processing.can_transition_to(&succeeded));


### PR DESCRIPTION
Enable Enqueued jobs to transition directly to the Failed state, accommodating scenarios such as configuration errors. Update tests to reflect this new state transition.